### PR TITLE
DB Seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ erl_crash.dump
 .local.plt.hash
 
 
+/apps/catalog/priv/repo/structure.sql

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,7 @@ script:
   - MIX_ENV=test mix do compile --warnings-as-errors
   - mix credo --strict
   - mix dialyzer
+  - MIX_ENV=test mix ecto.create --repo Catalog.Repo
+  - MIX_ENV=test mix load_usda_catalog
   - MIX_ENV=test mix coveralls.travis --umbrella
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # USDASearch
 
-### Seed DB
+### Seed DB - 2018-05-11
 
 - Github can't host files bigger than 100mb, so, compressed the USDA sql.
 - Add ecto and postgrex dependencies to catalog app.
@@ -10,7 +10,7 @@
 - Add the sql file to .gitignore
 - Modify `.travis.yml` to run tasks for seeding the db.
 
-### Initial project setup.
+### Initial project setup. - 2018-05-07
 
 - Create new umbrella app (`mix new usda_search --umbrella`).
 - Create empty catalog app within the umbrella `apps` folder (`mix new catalog`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # USDASearch
 
+### Seed DB
+
+- Github can't host files bigger than 100mb, so, compressed the USDA sql.
+- Add ecto and postgrex dependencies to catalog app.
+- Add basic OTP app structure to catalog.
+- Add config files.
+- `mix ecto.load` by default will search for a file under `priv/repo/structure.sql`. Since that file is to big to host on github, the file was compressed, and a mix task was created to handle unzipping, and loading it into the db.
+- Add the sql file to .gitignore
+- Modify `.travis.yml` to run tasks for seeding the db.
+
 ### Initial project setup.
 
 - Create new umbrella app (`mix new usda_search --umbrella`).

--- a/apps/catalog/config/config.exs
+++ b/apps/catalog/config/config.exs
@@ -1,30 +1,8 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
+config :catalog,
+  ecto_repos: [
+    Catalog.Repo
+  ]
 
-# You can configure your application as:
-#
-#     config :catalog, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:catalog, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/apps/catalog/config/dev.exs
+++ b/apps/catalog/config/dev.exs
@@ -1,0 +1,9 @@
+use Mix.Config
+
+config :catalog, Catalog.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: "postgres",
+  password: "postgres",
+  database: "usda_catalog_db_dev",
+  hostname: "localhost",
+  pool_size: 10

--- a/apps/catalog/config/prod.exs
+++ b/apps/catalog/config/prod.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+import_config "prod.secret.exs"

--- a/apps/catalog/config/test.exs
+++ b/apps/catalog/config/test.exs
@@ -1,0 +1,9 @@
+use Mix.Config
+
+config :catalog, Catalog.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: "postgres",
+  password: "postgres",
+  database: "usda_catalog_db_test",
+  hostname: "localhost",
+  pool: Ecto.Adapters.SQL.Sandbox

--- a/apps/catalog/lib/catalog.ex
+++ b/apps/catalog/lib/catalog.ex
@@ -2,17 +2,9 @@ defmodule Catalog do
   @moduledoc """
   Documentation for Catalog.
   """
+  use Application
 
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> Catalog.hello
-      :world
-
-  """
-  def hello do
-    :world
+  def start(_type, _args) do
+    Catalog.Supervisor.start_link()
   end
 end

--- a/apps/catalog/lib/mix/catalog/repo.ex
+++ b/apps/catalog/lib/mix/catalog/repo.ex
@@ -1,0 +1,4 @@
+defmodule Catalog.Repo do
+  @moduledoc false
+  use Ecto.Repo, otp_app: :catalog
+end

--- a/apps/catalog/lib/mix/catalog/supervisor.ex
+++ b/apps/catalog/lib/mix/catalog/supervisor.ex
@@ -1,0 +1,19 @@
+defmodule Catalog.Supervisor do
+  @moduledoc false
+  use Supervisor
+  alias Catalog.Repo
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [])
+  end
+
+  def init(_args) do
+    supervise(children(), strategy: :one_for_one)
+  end
+
+  defp children do
+    [
+      supervisor(Repo, [])
+    ]
+  end
+end

--- a/apps/catalog/lib/mix/tasks/load_usda_catalog.ex
+++ b/apps/catalog/lib/mix/tasks/load_usda_catalog.ex
@@ -15,18 +15,18 @@ defmodule Mix.Tasks.LoadUsdaCatalog do
 
   defp path, do: "#{System.cwd()}/apps/catalog/priv/repo/"
   defp file_name, do: "structure.sql"
-  defp zip_file, do: "#{path()}#{file_name}.zip"
+  defp zip_file, do: "#{path()}#{file_name()}.zip"
 
   defp unzip_file do
     {:ok, _} =
       zip_file()
-      |> String.to_char_list()
+      |> String.to_charlist()
       |> :zip.unzip()
   end
 
   defp move_file do
     sql_file = "#{System.cwd()}/structure.sql"
-    File.cp!(sql_file, "#{path}structure.sql")
+    File.cp!(sql_file, "#{path()}structure.sql")
     File.rm!(sql_file)
   end
 

--- a/apps/catalog/lib/mix/tasks/load_usda_catalog.ex
+++ b/apps/catalog/lib/mix/tasks/load_usda_catalog.ex
@@ -1,0 +1,34 @@
+defmodule Mix.Tasks.LoadUsdaCatalog do
+  use Mix.Task
+  alias Mix.Tasks.Ecto.Load
+
+  @moduledoc """
+  Mix task for unzipping and loading catalog sql.
+  """
+
+  @shortdoc "Unzip structure.sql.zip file."
+  def run(_) do
+    unzip_file()
+    move_file()
+    load_sql()
+  end
+
+  defp path, do: "#{System.cwd()}/apps/catalog/priv/repo/"
+  defp file_name, do: "structure.sql"
+  defp zip_file, do: "#{path()}#{file_name}.zip"
+
+  defp unzip_file do
+    {:ok, _} =
+      zip_file()
+      |> String.to_char_list()
+      |> :zip.unzip()
+  end
+
+  defp move_file do
+    sql_file = "#{System.cwd()}/structure.sql"
+    File.cp!(sql_file, "#{path}structure.sql")
+    File.rm!(sql_file)
+  end
+
+  defp load_sql, do: Load.run(["-r", "Catalog.Repo"])
+end

--- a/apps/catalog/mix.exs
+++ b/apps/catalog/mix.exs
@@ -23,6 +23,8 @@ defmodule Catalog.MixProject do
 
   defp deps do
     [
+      {:postgrex, ">= 0.0.0"},
+      {:ecto, "~> 2.2.10"}
     ]
   end
 end

--- a/apps/catalog/test/catalog_test.exs
+++ b/apps/catalog/test/catalog_test.exs
@@ -1,8 +1,4 @@
 defmodule CatalogTest do
   use ExUnit.Case
   doctest Catalog
-
-  test "greets the world" do
-    assert Catalog.hello() == :world
-  end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,12 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "0.9.2", "841d316612f568beb22ba310d816353dddf31c2d94aa488ae5a27bb53760d0bf", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "db_connection": {:hex, :db_connection, "1.1.3", "89b30ca1ef0a3b469b1c779579590688561d586694a3ce8792985d4d7e575a61", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "2.2.10", "e7366dc82f48f8dd78fcbf3ab50985ceeb11cb3dc93435147c6e13f2cda0992e", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.8.2", "b941a08a1842d7aa629e0bbc969186a4cefdd035bad9fe15d43aaaaaeb8fae36", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.12.1", "8bf2d0e11e722e533903fe126e14d6e7e94d9b7983ced595b75f532e04b7fdc7", [:rebar3], [{:certifi, "2.3.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.1", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
@@ -12,6 +16,8 @@
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+  "postgrex": {:hex, :postgrex, "0.13.5", "3d931aba29363e1443da167a4b12f06dcd171103c424de15e5f3fc2ba3e6d9c5", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
Fixes #4 . Copy paste from changelog. 
```
- Github can't host files bigger than 100mb, so, compressed the USDA sql.
- Add ecto and postgrex dependencies to catalog app.
- Add basic OTP app structure to catalog.
- Add config files.
- mix ecto.load by default will search for a file under priv/repo/structure.sql. Since that file is to big to host on github, the file was compressed, and a mix task was created to handle unzipping, and loading it into the db.
- Add the sql file to .gitignore
- Modify .travis.yml to run tasks for seeding the db.
```
Sorry for the big PR. 🙈