### PR TITLE
Pre commit hooks

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,4 +2,4 @@ use Mix.Config
 
 import_config "../apps/*/config/config.exs"
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,4 +2,4 @@ use Mix.Config
 
 import_config "../apps/*/config/config.exs"
 
-import_config "#{Mix.env()}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,17 +1,5 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# By default, the umbrella project as well as each child
-# application will require this configuration file, ensuring
-# they all use the same configuration. While one could
-# configure all applications here, we prefer to delegate
-# back to each application for organization purposes.
 import_config "../apps/*/config/config.exs"
 
-# Sample configuration (overrides the imported configuration above):
-#
-#     config :logger, :console,
-#       level: :info,
-#       format: "$date $time [$level] $metadata$message\n",
-#       metadata: [:user_id]
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
 config :pre_commit,
-  commands: ["format", "credo", "test"],
+  commands: ["format --check-formatted", "credo", "test"],
   verbose: true

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :pre_commit,
+  commands: ["format", "credo", "test"],
+  verbose: true

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
 config :pre_commit,
-  commands: ["format --check-formatted", "credo", "test"],
+  commands: ["format --check-formatted", "credo --strict", "test"],
   verbose: true

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+import_config "prod.secret.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,7 @@ defmodule UsdaSearch.MixProject do
 
   defp deps do
     [
+      {:pre_commit, "~> 0.2.4", only: :dev},
       {:credo, "~> 0.9.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:excoveralls, "~> 0.8.1", only: [:test]}

--- a/mix.lock
+++ b/mix.lock
@@ -29,6 +29,7 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.13.5", "3d931aba29363e1443da167a4b12f06dcd171103c424de15e5f3fc2ba3e6d9c5", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
+  "pre_commit": {:hex, :pre_commit, "0.2.4", "e26feaa149d55d3a6f14ca1340bd8738942d98405de389c0b3c7d48e71e62d66", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
Prevent failed builds because of data not being properly formatted, missing styling suggestion by the static code analysis or failing tests.